### PR TITLE
refactor: move c8y-nitro options to nitro root config

### DIFF
--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -9,11 +9,13 @@ export default defineNitroConfig({
     openAPI: true,
   },
 
+  c8y: {
+    manifest: {
+      roles: ['SOME_CUSTOM_ROLE', 'ANOTHER_ROLE'],
+    },
+  },
+
   modules: [
-    c8y({
-      manifest: {
-        roles: ['SOME_CUSTOM_ROLE', 'ANOTHER_ROLE'],
-      },
-    }),
+    c8y(),
   ],
 })

--- a/playground/routes/index.get.ts
+++ b/playground/routes/index.get.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler } from 'nitro/h3'
+import { c8yRoles } from 'c8y-nitro/runtime'
+
+export default defineEventHandler(() => {
+  return `Available roles: ${Object.values(c8yRoles).join(', ')}`
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,17 @@ import { setupRuntime } from './dev/runtime'
 import { registerRuntime } from './dev/register'
 import { checkProbes } from './dev/probeCheck'
 
-export function c8y(options: C8yNitroModuleOptions = {}): NitroModule {
+declare module 'nitro/types' {
+  interface NitroOptions {
+    c8y?: C8yNitroModuleOptions
+  }
+}
+export function c8y(): NitroModule {
   return {
     name: 'c8y-nitro',
     setup: async (nitro) => {
+      const options = nitro.options.c8y ?? {}
+
       // enable tsconfig generation
       nitro.options.typescript.generateTsConfig = true
       // workaround as the generated tsconfig creates an invalid extends entry


### PR DESCRIPTION
This is necessary to load the options later from nitro/builder `loadConfig` later on in cli