### PR TITLE
fix: enforce non-empty default values for manifest settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ export default defineNitroConfig({
     manifest: {
       settings: [
         { key: 'myOption', defaultValue: 'default' },
-        { key: 'credentials.secret' }, // Encrypted option
+        { key: 'credentials.secret', defaultValue: 'change-me' }, // Encrypted option
       ],
       settingsCategory: 'my-service', // Optional, defaults to contextPath/name
       requiredRoles: ['ROLE_OPTION_MANAGEMENT_READ'], // Required for reading tenant options
@@ -465,6 +465,8 @@ export default defineNitroConfig({
   modules: [c8y()],
 })
 ```
+
+`manifest.settings[].defaultValue` is required and must be a non-empty string. `''` is rejected during manifest generation so invalid settings fail early during development/build.
 
 > **Important**: To read tenant options, your microservice **must** have the `ROLE_OPTION_MANAGEMENT_READ` role in `manifest.requiredRoles`. Without this role, API calls will fail with a 403 Forbidden error.
 

--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -15,8 +15,8 @@ export default defineNitroConfig({
     manifest: {
       roles: ['SOME_CUSTOM_ROLE', 'ANOTHER_ROLE'],
       settings: [
-        { key: 'myOption' },
-        { key: 'credentials.secret' },
+        { key: 'myOption', defaultValue: 'default' },
+        { key: 'credentials.secret', defaultValue: 'change-me' },
       ],
       requiredRoles: ['ROLE_OPTION_MANAGEMENT_READ'],
     },

--- a/src/module/manifest.ts
+++ b/src/module/manifest.ts
@@ -11,6 +11,17 @@ interface PackageJsonFields {
   contextPath: string
 }
 
+function validateManifestSettings(options: C8YManifestOptions): void {
+  const invalidSettings = options.settings?.filter((setting) => typeof setting.defaultValue !== 'string' || setting.defaultValue.length === 0) ?? []
+
+  if (invalidSettings.length === 0) {
+    return
+  }
+
+  const invalidKeys = invalidSettings.map((setting) => `"${setting.key}"`).join(', ')
+  throw new Error(`manifest.settings entries must define a non-empty defaultValue. Invalid keys: ${invalidKeys}`)
+}
+
 async function readPackageJsonFieldsForManifest(
   rootDir: string,
   logger?: ConsolaInstance,
@@ -62,6 +73,8 @@ export async function createC8yManifest(
   options: C8YManifestOptions = {},
   logger?: ConsolaInstance,
 ): Promise<C8YManifest> {
+  validateManifestSettings(options)
+
   const {
     name,
     version,

--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -204,10 +204,10 @@ export interface Option {
   key: string
 
   /**
-   * Initial value if not overridden.
+   * Initial non-empty value if not overridden.
    * @example "1234"
    */
-  defaultValue?: string
+  defaultValue: string
 
   /**
    * Allow tenants to modify at runtime.

--- a/tests/server/fixture/nitro.config.ts
+++ b/tests/server/fixture/nitro.config.ts
@@ -17,8 +17,8 @@ export default defineNitroConfig({
     manifest: {
       roles: ['SOME_CUSTOM_ROLE', 'ANOTHER_ROLE'],
       settings: [
-        { key: 'myOption' },
-        { key: 'credentials.secret' },
+        { key: 'myOption', defaultValue: 'default' },
+        { key: 'credentials.secret', defaultValue: 'change-me' },
       ],
       requiredRoles: ['ROLE_OPTION_MANAGEMENT_READ'],
     },

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -156,6 +156,39 @@ describe('manifest generation', () => {
       expect(manifest.resources).toEqual({ cpu: '500m', memory: '512M' })
     })
 
+    it('should throw error when a setting default value is empty', async () => {
+      mockPackageData.current = {
+        name: 'my-service',
+        version: '1.0.0',
+        author: 'Test Author',
+      }
+
+      await expect(createC8yManifest('/project', {
+        settings: [
+          { key: 'valid.setting', defaultValue: 'configured' },
+          { key: 'credentials.secret', defaultValue: '' },
+        ],
+      }))
+        .rejects
+        .toThrow('manifest.settings entries must define a non-empty defaultValue. Invalid keys: "credentials.secret"')
+    })
+
+    it('should throw error when a setting default value is missing', async () => {
+      mockPackageData.current = {
+        name: 'my-service',
+        version: '1.0.0',
+        author: 'Test Author',
+      }
+
+      await expect(createC8yManifest('/project', {
+        settings: [
+          { key: 'credentials.secret' } as never,
+        ],
+      }))
+        .rejects
+        .toThrow('manifest.settings entries must define a non-empty defaultValue. Invalid keys: "credentials.secret"')
+    })
+
     it('should throw error when package.json is missing required fields', async () => {
       mockPackageData.current = {
         name: 'my-service',


### PR DESCRIPTION
resolves #36