### PR TITLE
refactor: use Nitro cache invalidation helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,14 +254,16 @@ await nitro.close()
 
 #### Limitations
 
-Virtual module mocking injects static data at build time. This means:
+Virtual module mocking injects module code at build time. By default, the generated mock data is static per server instance, but the mock module can also expose explicit helper functions for controlled runtime mutation when a test needs to simulate backend state changes.
 
-- **No runtime data changes**: You cannot modify mock data mid-test (e.g., to test cache invalidation or TTL expiration)
-- **No state verification**: Cannot assert that a function wrote to the "database" or called the API a specific number of times
-- **One mock per server**: Changing mock data requires building a new server instance
+- **Static by default**: Most mock data is fixed per built server instance unless the virtual module intentionally exposes mutable helpers
+- **Controlled runtime mutation is possible**: For cache invalidation or TTL-expiration tests, add explicit helper exports to the virtual module and trigger them through fixture routes so the bundled server mutates its own in-memory mock state
+- **No call-count/state introspection by default**: Cannot assert writes or API call counts unless the virtual module is extended to record that state
+- **One virtual module per server build**: Changing the mock implementation itself still requires building a new server instance
 
 For testing cache behavior, TTL expiration, or stateful interactions, consider:
 
+- Extending the virtual module with focused runtime mutation helpers and hitting them through fixture routes
 - Unit testing the caching logic separately with mocked dependencies
 - Using the playground with a real Cumulocity tenant for manual verification
 
@@ -408,11 +410,15 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - **Structured errors** — always use `createError` from `c8y-nitro/utils` (re-exported from `evlog`) instead of Nitro/h3's built-in `createError`. This ensures the `why`, `fix`, and `link` fields are captured in the wide log event and returned in the JSON response under a `data` key.
 - **Logging test pattern** — Use `consola.mockTypes()` + `consola.wrapAll()` in `it.sequential` tests, then `consola.restoreAll()` in a `finally` block. Capturing logs with `vi.fn((context) => logs.push(String(context)))` is fine when passed through `consola.mockTypes()`. Wait 100ms after the request for async log emission before asserting on `logOutput`.
 - **Server fixture test dependency** — `tests/server/fixture/` exercises the built package. After changing module/runtime behavior used by fixture tests, run `pnpm build` before running those tests or the fixture server may still use stale output.
+- **Nitro workspace version alignment** — Keep `pnpm-workspace.yaml`'s Nitro catalog version aligned with the package-level Nitro version before diagnosing Nitro type or cache helper behavior. A catalog mismatch can leave the workspace on an older Nitro build and make cache helper typings or runtime assumptions look wrong.
+- **Nitro cache typing gap** — In Nitro `3.0.260429-beta`, `defineCachedFunction()` runtime/docs expose `.invalidate()` and `.resolveKeys()`, but Nitro's exported TypeScript declaration still returns a plain cached function signature without those helper members. When using Nitro's built-in cache invalidation helpers from TypeScript, keep a narrow local cast around the cached function until Nitro updates its type declarations.
 - **Scheduled task test pattern** — Enable `experimental.tasks: true` in the fixture config and place a real Nitro task in `tests/server/fixture/tasks/` so Nitro auto-registers it; do not add a manual `tasks` handler path unless the test specifically needs one. Nitro derives task names from file paths, so use nested paths like `tasks/scheduler/log.ts` for `scheduler:log`. Schedule it through a route using `scheduleTask()`, assert all captured logs do not contain the task marker immediately after the request, then sleep until `runAt` plus a generous buffer and assert the marker appears. Do not use `vi.waitFor()` for this built fixture timing check. Reuse an existing fixture server `describe` block when possible instead of adding another server setup just for scheduler coverage. Use `consola.mockTypes()` + `consola.wrapAll()` for log assertions, and make fixture tasks log through the standalone `createLogger()` utility so task logs use the same consola-backed logging path as the app.
+- **Shared fixture cache tests** — When adding cache-expiration coverage to an existing shared server describe block, prefer introducing a dedicated manifest-defined tenant option key used only by that test instead of reusing a key that other assertions depend on. This avoids cross-test state coupling while still saving the extra server startup/teardown cost.
 
 - Utility functions accept `H3Event | ServerRequest` for flexibility
 - Use `defineCachedFunction` from Nitro for cached API calls (e.g., credentials)
   - Always include `invalidate` and `refresh` helper functions
+  - Prefer Nitro/ocache's built-in cached function `.invalidate()` over manually constructing storage keys with `useStorage('cache').removeItem(...)`; manual keys are easy to get wrong when `group`, `base`, or `getKey` differ from defaults
   - Carefully consider what requests make sense to be cached (e.g., credentials, not real-time data, consider security implications)
   - For per-key caching (like tenant options), use a factory pattern with a Map/Record to store fetchers
   - `maxAge` does NOT accept a function — if you need per-key TTL, create separate cached functions per key

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -6,7 +6,6 @@ import { HTTPError } from 'nitro/h3'
 import type { ServerRequest } from 'nitro/types'
 import process from 'node:process'
 import { getCurrentUserTenantId } from './internal/tenant'
-import { useStorage } from 'nitro/storage'
 import { useRuntimeConfig } from 'nitro/runtime-config'
 
 /**
@@ -31,44 +30,44 @@ import { useRuntimeConfig } from 'nitro/runtime-config'
  * // Force refresh:
  * const freshCreds = await useSubscribedTenantCredentials.refresh()
  */
-export const useSubscribedTenantCredentials = Object.assign(
-  defineCachedFunction(async () => {
-    // all env vars are enforced to be set
-    const subscriptions = await Client.getMicroserviceSubscriptions({
-      tenant: process.env.C8Y_BOOTSTRAP_TENANT!,
-      user: process.env.C8Y_BOOTSTRAP_USER!,
-      password: process.env.C8Y_BOOTSTRAP_PASSWORD!,
-    }, process.env.C8Y_BASEURL!)
+// TODO: Remove this cast once Nitro's `defineCachedFunction()` types expose ocache's `.invalidate()` helper.
+const cachedSubscribedTenantCredentials = defineCachedFunction(async () => {
+  // all env vars are enforced to be set
+  const subscriptions = await Client.getMicroserviceSubscriptions({
+    tenant: process.env.C8Y_BOOTSTRAP_TENANT!,
+    user: process.env.C8Y_BOOTSTRAP_USER!,
+    password: process.env.C8Y_BOOTSTRAP_PASSWORD!,
+  }, process.env.C8Y_BASEURL!)
 
-    // we map them as an object with tenant as key for easier access
-    return subscriptions.reduce(
-      (acc, cred) => {
-        if (cred.tenant) {
-          acc[cred.tenant] = cred
-        }
-        return acc
-      },
-      {} as Record<string, ICredentials>,
-    )
-  }, {
-    maxAge: useRuntimeConfig().c8yCredentialsCacheTTL ?? 600,
-    name: '_c8y_nitro_get_subscribed_tenant_credentials',
-    group: 'c8y_nitro',
-    swr: false,
-  }),
-  {
-    invalidate: async () => {
-      const completeKey = `c8y_nitro:functions:_c8y_nitro_get_subscribed_tenant_credentials.json`
-      await useStorage('cache').removeItem(completeKey)
+  // we map them as an object with tenant as key for easier access
+  return subscriptions.reduce(
+    (acc, cred) => {
+      if (cred.tenant) {
+        acc[cred.tenant] = cred
+      }
+      return acc
     },
-    refresh: async () => {
-      // call the invalidate part
-      await useSubscribedTenantCredentials.invalidate()
-      // then call the function to refresh
-      return await useSubscribedTenantCredentials()
-    },
+    {} as Record<string, ICredentials>,
+  )
+}, {
+  maxAge: useRuntimeConfig().c8yCredentialsCacheTTL ?? 600,
+  name: '_c8y_nitro_get_subscribed_tenant_credentials',
+  group: 'c8y_nitro',
+  swr: false,
+}) as (() => Promise<Record<string, ICredentials>>) & {
+  invalidate: () => Promise<void>
+}
+
+// TODO: Remove this explicit type once Nitro's `defineCachedFunction()` return type includes ocache helper methods.
+export const useSubscribedTenantCredentials: (() => Promise<Record<string, ICredentials>>) & {
+  invalidate: () => Promise<void>
+  refresh: () => Promise<Record<string, ICredentials>>
+} = Object.assign(cachedSubscribedTenantCredentials, {
+  refresh: async () => {
+    await cachedSubscribedTenantCredentials.invalidate()
+    return await cachedSubscribedTenantCredentials()
   },
-)
+})
 
 /**
  * Fetches credentials for the tenant where this microservice is deployed.\
@@ -88,7 +87,11 @@ export const useSubscribedTenantCredentials = Object.assign(
  * const freshCreds = await useDeployedTenantCredentials.refresh()
  * @note This function is not cached separately. It uses the cache of `useSubscribedTenantCredentials()`. Invalidating or refreshing one will refresh `useDeployedTenantCredentials()`s cache.
  */
-export const useDeployedTenantCredentials = Object.assign(async (): Promise<ICredentials> => {
+// TODO: Remove this explicit type once Nitro's `defineCachedFunction()` return type includes ocache helper methods.
+export const useDeployedTenantCredentials: (() => Promise<ICredentials>) & {
+  invalidate: () => Promise<void>
+  refresh: () => Promise<ICredentials>
+} = Object.assign(async (): Promise<ICredentials> => {
   const tenant = process.env.C8Y_BOOTSTRAP_TENANT!
   const allCredsPromise = await useSubscribedTenantCredentials()
   if (!allCredsPromise[tenant]) {
@@ -102,9 +105,7 @@ export const useDeployedTenantCredentials = Object.assign(async (): Promise<ICre
 }, {
   invalidate: useSubscribedTenantCredentials.invalidate,
   refresh: async () => {
-    // call the invalidate part
-    await useDeployedTenantCredentials.invalidate()
-    // then call the function to refresh
+    await useSubscribedTenantCredentials.refresh()
     return await useDeployedTenantCredentials()
   },
 })

--- a/src/utils/tenantOptions.ts
+++ b/src/utils/tenantOptions.ts
@@ -1,5 +1,4 @@
 import { defineCachedFunction } from 'nitro/cache'
-import { useStorage } from 'nitro/storage'
 import { useRuntimeConfig } from 'nitro/runtime-config'
 import { useDeployedTenantClient } from './client'
 import type { C8YTenantOptionKey } from 'c8y-nitro/types'
@@ -24,7 +23,8 @@ function getTenantOptionCacheTTL(key: C8YTenantOptionKey): number {
 function createCachedTenantOptionFetcher(key: C8YTenantOptionKey): CachedTenantOptionFetcher {
   const cacheName = `_c8y_nitro_tenant_option_${key.replace(/\./g, '_')}`
 
-  const fetcher = defineCachedFunction(
+  // TODO: Remove this cast once Nitro's `defineCachedFunction()` types expose ocache's `.invalidate()` helper.
+  const cachedFetcher = defineCachedFunction(
     async (): Promise<string | undefined> => {
       const client = await useDeployedTenantClient()
       const category = useRuntimeConfig().c8ySettingsCategory as string
@@ -50,19 +50,18 @@ function createCachedTenantOptionFetcher(key: C8YTenantOptionKey): CachedTenantO
       group: 'c8y_nitro',
       swr: false,
     },
-  )
+  ) as (() => Promise<string | undefined>) & {
+    invalidate: () => Promise<void>
+  }
 
-  return Object.assign(fetcher, {
-    invalidate: async (): Promise<void> => {
-      const completeKey = `c8y_nitro:functions:${cacheName}.json`
-      await useStorage('cache').removeItem(completeKey)
-    },
+  const fetcher: CachedTenantOptionFetcher = Object.assign(cachedFetcher, {
     refresh: async (): Promise<string | undefined> => {
-      const completeKey = `c8y_nitro:functions:${cacheName}.json`
-      await useStorage('cache').removeItem(completeKey)
-      return await fetcher()
+      await cachedFetcher.invalidate()
+      return await cachedFetcher()
     },
   })
+
+  return fetcher
 }
 
 /**

--- a/tests/server/fixture/nitro.config.ts
+++ b/tests/server/fixture/nitro.config.ts
@@ -20,6 +20,7 @@ export default defineNitroConfig({
       settings: [
         { key: 'myOption', defaultValue: 'default' },
         { key: 'credentials.secret', defaultValue: 'change-me' },
+        { key: 'cacheExpiryOption', defaultValue: 'cache-default' },
       ],
       requiredRoles: ['ROLE_OPTION_MANAGEMENT_READ'],
     },

--- a/tests/server/fixture/routes/mock-tenant-option.get.ts
+++ b/tests/server/fixture/routes/mock-tenant-option.get.ts
@@ -1,0 +1,30 @@
+import * as c8yClient from '@c8y/client'
+import { defineEventHandler, getQuery } from 'nitro/h3'
+
+const mockTenantOptionApi = c8yClient as unknown as {
+  __setMockTenantOption: (key: string, value: string) => void
+  __deleteMockTenantOption: (key: string) => void
+  __getMockTenantOption: (key: string) => string | undefined
+}
+
+export default defineEventHandler((event) => {
+  const query = getQuery(event)
+  const key = String(query.key ?? '')
+
+  if (!key) {
+    return {
+      message: 'Missing key',
+    }
+  }
+
+  if (query.value === undefined) {
+    mockTenantOptionApi.__deleteMockTenantOption(key)
+  } else {
+    mockTenantOptionApi.__setMockTenantOption(key, String(query.value))
+  }
+
+  return {
+    key,
+    value: mockTenantOptionApi.__getMockTenantOption(key) ?? null,
+  }
+})

--- a/tests/server/fixture/routes/tenant-options.get.ts
+++ b/tests/server/fixture/routes/tenant-options.get.ts
@@ -4,10 +4,12 @@ import { useTenantOption } from 'c8y-nitro/utils'
 export default defineEventHandler(async () => {
   const myOption = await useTenantOption('myOption')
   const secret = await useTenantOption('credentials.secret')
+  const cacheExpiryOption = await useTenantOption('cacheExpiryOption')
 
   return {
     myOption,
     'credentials.secret': secret,
+    cacheExpiryOption,
     'message': 'Fetched tenant options successfully',
   }
 })

--- a/tests/server/mocks/generator.ts
+++ b/tests/server/mocks/generator.ts
@@ -10,8 +10,12 @@ export interface MockC8yClientData {
 }
 
 /**
- * Generates virtual module code for \@c8y/client mock with predefined static data
- * This is used by Nitro's virtual modules to replace \@c8y/client imports during build
+ * Generates virtual module code for \@c8y/client mock with predefined test data.
+ * This is used by Nitro's virtual modules to replace \@c8y/client imports during build.
+ *
+ * The generated mock keeps tenant options in mutable module state so fixture routes can
+ * simulate changing server-side data and exercise cache expiration/invalidation behavior.
+ *
  * @param data - Mock data to be returned by the Client methods (currentUser, subscriptions, tenantOptions)
  */
 export function generateMockClientCode(data: MockC8yClientData = {}): string {
@@ -37,6 +41,18 @@ export function generateMockClientCode(data: MockC8yClientData = {}): string {
 const mockCurrentUser = ${currentUserCode}
 const mockSubscriptions = ${subscriptionsCode}
 const mockTenantOptions = ${tenantOptionsCode}
+
+export function __setMockTenantOption(key, value) {
+  mockTenantOptions[key] = value
+}
+
+export function __deleteMockTenantOption(key) {
+  delete mockTenantOptions[key]
+}
+
+export function __getMockTenantOption(key) {
+  return mockTenantOptions[key]
+}
 
 /**
  * Mock BasicAuth class

--- a/tests/server/server.test.ts
+++ b/tests/server/server.test.ts
@@ -330,6 +330,15 @@ describe('Nitro Server', () => {
     beforeAll(async () => {
       const result = await createC8yNitroServer({
         env: completeEnv,
+        nitroConfig: {
+          c8y: {
+            cache: {
+              tenantOptions: {
+                cacheExpiryOption: 4,
+              },
+            },
+          },
+        },
         mockData: {
           currentUser: {
             userName: 'testUser',
@@ -346,6 +355,7 @@ describe('Nitro Server', () => {
           tenantOptions: {
             'myOption': 'hello-world',
             'credentials.secret': 'super-secret-value',
+            'cacheExpiryOption': 'cache-initial-value',
           },
         },
       })
@@ -392,6 +402,7 @@ describe('Nitro Server', () => {
       const json = await res.json()
       expect(json.myOption).toBe('hello-world')
       expect(json['credentials.secret']).toBe('super-secret-value')
+      expect(json.cacheExpiryOption).toBe('cache-initial-value')
       expect(json.message).toBe('Fetched tenant options successfully')
     })
 
@@ -461,6 +472,39 @@ describe('Nitro Server', () => {
       const json = await res.json()
       expect(json.message).toBe('You are from the deployed tenant!')
     })
+
+    it('should keep the cached tenant option until TTL expires and then return the updated value', async () => {
+      const initialRes = await server.fetch(new Request(new URL('/tenant-options', server.url)))
+      expect(initialRes.status).toEqual(200)
+      const initialJson = await initialRes.json()
+      expect(initialJson.cacheExpiryOption).toBe('cache-initial-value')
+
+      const updateRes = await server.fetch(new Request(new URL('/mock-tenant-option?key=cacheExpiryOption&value=cache-updated-value', server.url)))
+      expect(updateRes.status).toEqual(200)
+      const updateJson = await updateRes.json()
+      expect(updateJson).toEqual({
+        key: 'cacheExpiryOption',
+        value: 'cache-updated-value',
+      })
+
+      await new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 2_000)
+      })
+
+      const cachedRes = await server.fetch(new Request(new URL('/tenant-options', server.url)))
+      expect(cachedRes.status).toEqual(200)
+      const cachedJson = await cachedRes.json()
+      expect(cachedJson.cacheExpiryOption).toBe('cache-initial-value')
+
+      await new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 3_200)
+      })
+
+      const refreshedRes = await server.fetch(new Request(new URL('/tenant-options', server.url)))
+      expect(refreshedRes.status).toEqual(200)
+      const refreshedJson = await refreshedRes.json()
+      expect(refreshedJson.cacheExpiryOption).toBe('cache-updated-value')
+    }, 8_000)
   })
 
   describe('Tenant restriction (disallowed tenant)', () => {


### PR DESCRIPTION
## Summary

Refactor cached credential and tenant-option helpers to use Nitro/ocache's built-in cache invalidation APIs instead of manual storage-key deletion.

## Changes

- switch credential cache refresh/invalidation to cached function \.invalidate()
- switch tenant option cache refresh/invalidation to cached function \.invalidate()
- keep narrow local casts and TODO comments where Nitro runtime supports ocache helpers but exported typings do not yet expose them
- add server coverage for tenant-option TTL expiration using a dedicated fixture tenant option key
- extend the virtual @c8y/client mock with controlled runtime mutation helpers for cache-behavior tests
- reuse the existing shared fixture server block for the TTL test to avoid extra startup/teardown cost
- update AGENTS.md with notes about Nitro workspace version alignment, the Nitro cache typing gap, and shared fixture cache-test patterns

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test:run