### PR TITLE
feat: implement tenant credentials lifecycle hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ src/
 │   ├── index.ts                # Main type exports (C8yNitroModuleOptions)
 │   ├── apiClient.ts            # API client generation types
 │   ├── cache.ts                # Cache configuration types
+│   ├── credentials.ts          # Shared tenant credential map types (TenantCredentials)
 │   ├── manifest.ts             # Manifest types (C8YManifest, C8YManifestOptions)
 │   ├── roles.ts                # Role types
 │   ├── tenantOptions.ts        # Tenant option key types
@@ -414,6 +415,7 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - **Nitro cache typing gap** — In Nitro `3.0.260429-beta`, `defineCachedFunction()` runtime/docs expose `.invalidate()` and `.resolveKeys()`, but Nitro's exported TypeScript declaration still returns a plain cached function signature without those helper members. When using Nitro's built-in cache invalidation helpers from TypeScript, keep a narrow local cast around the cached function until Nitro updates its type declarations.
 - **Scheduled task test pattern** — Enable `experimental.tasks: true` in the fixture config and place a real Nitro task in `tests/server/fixture/tasks/` so Nitro auto-registers it; do not add a manual `tasks` handler path unless the test specifically needs one. Nitro derives task names from file paths, so use nested paths like `tasks/scheduler/log.ts` for `scheduler:log`. Schedule it through a route using `scheduleTask()`, assert all captured logs do not contain the task marker immediately after the request, then sleep until `runAt` plus a generous buffer and assert the marker appears. Do not use `vi.waitFor()` for this built fixture timing check. Reuse an existing fixture server `describe` block when possible instead of adding another server setup just for scheduler coverage. Use `consola.mockTypes()` + `consola.wrapAll()` for log assertions, and make fixture tasks log through the standalone `createLogger()` utility so task logs use the same consola-backed logging path as the app.
 - **Shared fixture cache tests** — When adding cache-expiration coverage to an existing shared server describe block, prefer introducing a dedicated manifest-defined tenant option key used only by that test instead of reusing a key that other assertions depend on. This avoids cross-test state coupling while still saving the extra server startup/teardown cost.
+- **Lifecycle hook fixture tests** — Reuse an existing shared fixture server `describe` block when the required mock data already matches instead of creating another `beforeAll`/`afterAll` server pair. For credential lifecycle coverage, prefer one fixture plugin that records hook events plus two routes: one route that reads/mutates/refreshes the credential cache through query params and one route that returns/clears recorded hook events.
 
 - Utility functions accept `H3Event | ServerRequest` for flexibility
 - Use `defineCachedFunction` from Nitro for cached API calls (e.g., credentials)
@@ -425,6 +427,10 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - Generated types are consolidated into a single `c8y-nitro.d.ts` file for performance
   - Written to `node_modules/.nitro/types/` by `setupRuntime()`
   - Augments `c8y-nitro/types` and `c8y-nitro/runtime` modules
+- Public Nitro hook augmentations that consumers should get from `import 'c8y-nitro'` must live in the root entrypoint type graph
+  - Put `declare module 'nitro/types'` hook augmentations in `src/index.ts` so they are emitted in `dist/index.d.mts`
+  - Export shared hook payload types from `c8y-nitro/types` (for example `TenantCredentials`) and reference those in the augmentation instead of repeating inline records
+  - Do not hide consumer-facing Nitro hook augmentations only behind `c8y-nitro/types`-only files unless the root entrypoint imports them for declaration generation
 - Virtual module `c8y-nitro/runtime` exports runtime values (roles, tenant option keys)
   - Use `as const` for tuples to preserve literal types
   - Keep `src/runtime.d.ts` in sync as a fallback declaration

--- a/README.md
+++ b/README.md
@@ -421,6 +421,31 @@ async function anotherFunction() {
 >
 > **Cache Duration**: The cache TTL is configurable via the `cache.credentialsTTL` option or `NITRO_C8Y_CREDENTIALS_CACHE_TTL` environment variable. See [Cache Configuration](#cache-configuration) for details.
 
+#### Tenant credentials lifecycle hook
+
+`c8y-nitro` emits a Nitro runtime hook whenever the subscribed tenant credentials cache is populated or refreshed:
+
+- Hook: `c8y:tenantCredentialsUpdated`
+- Payload type: `TenantCredentials` from `c8y-nitro/types`
+
+```ts
+import type { TenantCredentials } from 'c8y-nitro/types'
+import { definePlugin } from 'nitro'
+
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks.hook('c8y:tenantCredentialsUpdated', (prev, next) => {
+    const previousTenants = prev ? Object.keys(prev) : []
+    const nextTenants = Object.keys(next)
+
+    console.log({ previousTenants, nextTenants })
+  })
+})
+```
+
+`prev` is `null` for the first population and otherwise contains the previously cached tenant credential map. `next` contains the newly fetched credentials keyed by tenant.
+
+If you extend this hook in your own code, prefer reusing exported types from `c8y-nitro/types` instead of repeating `Record<string, ICredentials>` locally.
+
 ### Tenant Options
 
 | Function            | Description                                              | Request Context |

--- a/__snapshots__/tsnapi/types.snapshot.d.ts
+++ b/__snapshots__/tsnapi/types.snapshot.d.ts
@@ -57,4 +57,5 @@ export interface C8YZipOptions {
 export type C8YManifestOptions = Omit<C8YManifest, 'name' | 'version' | 'apiVersion' | 'key' | 'type' | 'provider'>;
 export type C8YTenantOptionKey = string;
 export type C8YTenantOptionKeysCacheConfig = Partial<Record<C8YTenantOptionKey$1, number>>;
+export type TenantCredentials = Record<string, ICredentials>;
 // #endregion

--- a/__snapshots__/tsnapi/utils.snapshot.d.ts
+++ b/__snapshots__/tsnapi/utils.snapshot.d.ts
@@ -43,9 +43,9 @@ export declare const useDeployedTenantCredentials: (() => Promise<ICredentials>)
   invalidate: () => Promise<void>;
   refresh: () => Promise<ICredentials>;
 };
-export declare const useSubscribedTenantCredentials: (() => Promise<Record<string, ICredentials>>) & {
+export declare const useSubscribedTenantCredentials: (() => Promise<TenantCredentials>) & {
   invalidate: () => Promise<void>;
-  refresh: () => Promise<Record<string, ICredentials>>;
+  refresh: () => Promise<TenantCredentials>;
 };
 export declare const useTenantOption: ((key: C8YTenantOptionKey) => Promise<string | undefined>) & {
   invalidate: (key: C8YTenantOptionKey) => Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,20 @@ import { autoBootstrap } from './module/autoBootstrap'
 import { name as pkgName } from '../package.json'
 import evlog from 'evlog/nitro/v3'
 import { createC8yManifestFromNitro } from './module/manifest'
+import type { TenantCredentials } from './types/credentials'
 
 declare module 'nitro/types' {
   interface NitroOptions {
     c8y?: C8yNitroModuleOptions
   }
 }
+
+declare module 'nitro/types' {
+  interface NitroRuntimeHooks {
+    'c8y:tenantCredentialsUpdated': (prev: TenantCredentials | null, next: TenantCredentials) => void
+  }
+}
+
 export function c8y(): NitroModule {
   return {
     name: 'c8y-nitro',

--- a/src/types/credentials.ts
+++ b/src/types/credentials.ts
@@ -1,0 +1,3 @@
+import type { ICredentials } from '@c8y/client'
+
+export type TenantCredentials = Record<string, ICredentials>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export type * from './zip'
 export type { C8YManifestOptions, C8YManifest } from './manifest'
 export * from './apiClient'
 export type { C8yCacheOptions } from './cache'
+export type { TenantCredentials } from './credentials'
 
 export interface C8yDevOptions {
   /**

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -1,5 +1,6 @@
 import { Client } from '@c8y/client'
 import type { ICredentials } from '@c8y/client'
+import type { TenantCredentials } from '../types/credentials'
 import { defineCachedFunction } from 'nitro/cache'
 import type { H3Event } from 'nitro/h3'
 import { HTTPError } from 'nitro/h3'
@@ -7,6 +8,9 @@ import type { ServerRequest } from 'nitro/types'
 import process from 'node:process'
 import { getCurrentUserTenantId } from './internal/tenant'
 import { useRuntimeConfig } from 'nitro/runtime-config'
+import { useNitroHooks } from 'nitro/app'
+
+let prevCredentials: TenantCredentials | null = null
 
 /**
  * Fetches credentials for all tenants subscribed to this microservice.\
@@ -40,28 +44,34 @@ const cachedSubscribedTenantCredentials = defineCachedFunction(async () => {
   }, process.env.C8Y_BASEURL!)
 
   // we map them as an object with tenant as key for easier access
-  return subscriptions.reduce(
+  const newCredentials: TenantCredentials = subscriptions.reduce(
     (acc, cred) => {
       if (cred.tenant) {
         acc[cred.tenant] = cred
       }
       return acc
     },
-    {} as Record<string, ICredentials>,
+    {} as TenantCredentials,
   )
+
+  await useNitroHooks().callHook('c8y:tenantCredentialsUpdated', prevCredentials, newCredentials)
+
+  prevCredentials = newCredentials
+
+  return newCredentials
 }, {
   maxAge: useRuntimeConfig().c8yCredentialsCacheTTL ?? 600,
   name: '_c8y_nitro_get_subscribed_tenant_credentials',
   group: 'c8y_nitro',
   swr: false,
-}) as (() => Promise<Record<string, ICredentials>>) & {
+}) as (() => Promise<TenantCredentials>) & {
   invalidate: () => Promise<void>
 }
 
 // TODO: Remove this explicit type once Nitro's `defineCachedFunction()` return type includes ocache helper methods.
-export const useSubscribedTenantCredentials: (() => Promise<Record<string, ICredentials>>) & {
+export const useSubscribedTenantCredentials: (() => Promise<TenantCredentials>) & {
   invalidate: () => Promise<void>
-  refresh: () => Promise<Record<string, ICredentials>>
+  refresh: () => Promise<TenantCredentials>
 } = Object.assign(cachedSubscribedTenantCredentials, {
   refresh: async () => {
     await cachedSubscribedTenantCredentials.invalidate()

--- a/tests/server/fixture/plugins/tenant-credentials-updated.ts
+++ b/tests/server/fixture/plugins/tenant-credentials-updated.ts
@@ -1,0 +1,47 @@
+import type { TenantCredentials } from 'c8y-nitro/types'
+import { consola } from 'consola'
+import { definePlugin } from 'nitro'
+
+export interface CredentialHookEvent {
+  prevTenants: string[] | null
+  nextTenants: string[]
+}
+
+const credentialHookEvents: CredentialHookEvent[] = []
+
+export function recordCredentialHookEvent(
+  prev: TenantCredentials | null,
+  next: TenantCredentials,
+): CredentialHookEvent {
+  const event: CredentialHookEvent = {
+    prevTenants: prev ? Object.keys(prev).sort() : null,
+    nextTenants: Object.keys(next).sort(),
+  }
+
+  credentialHookEvents.push(event)
+
+  return event
+}
+
+export function getCredentialHookEvents(): CredentialHookEvent[] {
+  return credentialHookEvents.map((event) => ({
+    prevTenants: event.prevTenants ? [...event.prevTenants] : null,
+    nextTenants: [...event.nextTenants],
+  }))
+}
+
+export function clearCredentialHookEvents(): void {
+  credentialHookEvents.length = 0
+}
+
+export default definePlugin((nitroApp) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore -- VS Code does not always pick up the c8y-nitro Nitro hook augmentation in this fixture plugin.
+  nitroApp.hooks.hook('c8y:tenantCredentialsUpdated', (prev, next) => {
+    const event = recordCredentialHookEvent(prev, next)
+
+    consola.info(
+      `[test-hook] c8y:tenantCredentialsUpdated prev=${event.prevTenants?.join(',') ?? 'null'} next=${event.nextTenants.join(',')}`,
+    )
+  })
+})

--- a/tests/server/fixture/routes/credentials-hook-events.get.ts
+++ b/tests/server/fixture/routes/credentials-hook-events.get.ts
@@ -1,0 +1,15 @@
+import { defineEventHandler, getQuery } from 'nitro/h3'
+import { clearCredentialHookEvents, getCredentialHookEvents } from '../plugins/tenant-credentials-updated'
+
+export default defineEventHandler((event) => {
+  const query = getQuery(event)
+  const events = getCredentialHookEvents()
+
+  if (query.clear === '1') {
+    clearCredentialHookEvents()
+  }
+
+  return {
+    events,
+  }
+})

--- a/tests/server/fixture/routes/subscribed-credentials.get.ts
+++ b/tests/server/fixture/routes/subscribed-credentials.get.ts
@@ -1,0 +1,32 @@
+import * as c8yClient from '@c8y/client'
+import type { ICredentials } from '@c8y/client'
+import { useSubscribedTenantCredentials } from 'c8y-nitro/utils'
+import { defineEventHandler, getQuery } from 'nitro/h3'
+
+const mockSubscriptionApi = c8yClient as unknown as {
+  __setMockSubscription: (subscription: ICredentials) => void
+  __getMockSubscriptions: () => Array<ICredentials>
+}
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const tenant = typeof query.tenant === 'string' ? query.tenant : undefined
+  const user = typeof query.user === 'string' ? query.user : undefined
+  const password = typeof query.password === 'string' ? query.password : undefined
+
+  if (tenant && user && password) {
+    mockSubscriptionApi.__setMockSubscription({ tenant, user, password })
+  }
+
+  const credentials = query.refresh === '1'
+    ? await useSubscribedTenantCredentials.refresh()
+    : await useSubscribedTenantCredentials()
+
+  return {
+    subscribedTenants: Object.keys(credentials).sort(),
+    mockSubscribedTenants: mockSubscriptionApi.__getMockSubscriptions()
+      .map((subscription) => subscription.tenant)
+      .filter((subscriptionTenant): subscriptionTenant is string => Boolean(subscriptionTenant))
+      .sort(),
+  }
+})

--- a/tests/server/mocks/generator.ts
+++ b/tests/server/mocks/generator.ts
@@ -13,8 +13,9 @@ export interface MockC8yClientData {
  * Generates virtual module code for \@c8y/client mock with predefined test data.
  * This is used by Nitro's virtual modules to replace \@c8y/client imports during build.
  *
- * The generated mock keeps tenant options in mutable module state so fixture routes can
- * simulate changing server-side data and exercise cache expiration/invalidation behavior.
+ * The generated mock keeps subscriptions and tenant options in mutable module state so
+ * fixture routes can simulate changing server-side data and exercise cache expiration,
+ * invalidation, and lifecycle hook behavior.
  *
  * @param data - Mock data to be returned by the Client methods (currentUser, subscriptions, tenantOptions)
  */
@@ -41,6 +42,29 @@ export function generateMockClientCode(data: MockC8yClientData = {}): string {
 const mockCurrentUser = ${currentUserCode}
 const mockSubscriptions = ${subscriptionsCode}
 const mockTenantOptions = ${tenantOptionsCode}
+
+export function __setMockSubscription(subscription) {
+  const index = mockSubscriptions.findIndex((item) => item.tenant === subscription.tenant)
+
+  if (index === -1) {
+    mockSubscriptions.push(subscription)
+    return
+  }
+
+  mockSubscriptions[index] = subscription
+}
+
+export function __deleteMockSubscription(tenant) {
+  const index = mockSubscriptions.findIndex((item) => item.tenant === tenant)
+
+  if (index !== -1) {
+    mockSubscriptions.splice(index, 1)
+  }
+}
+
+export function __getMockSubscriptions() {
+  return mockSubscriptions.map((subscription) => ({ ...subscription }))
+}
 
 export function __setMockTenantOption(key, value) {
   mockTenantOptions[key] = value

--- a/tests/server/server.test.ts
+++ b/tests/server/server.test.ts
@@ -114,7 +114,7 @@ describe('Nitro Server', () => {
 
     it('should get the development user auth injected if present', async () => {
       const res = await server.fetch(new Request(new URL('/authHeader', server.url)))
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
 
       expect(json).toEqual({ authHeader: expect.any(String) })
 
@@ -146,7 +146,7 @@ describe('Nitro Server', () => {
 
         expect(res.status).toEqual(200)
 
-        const json = await res.json()
+        const json = await res.json() as Record<string, any>
         expect(json.scheduled).toEqual({
           id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
           task: 'scheduler:log',
@@ -162,7 +162,7 @@ describe('Nitro Server', () => {
         const listRes = await server.fetch(new Request(new URL('/scheduled-tasks', server.url)))
         expect(listRes.status).toEqual(200)
 
-        const listJson = await listRes.json()
+        const listJson = await listRes.json() as Record<string, any>
         expect(listJson.pending).not.toHaveProperty(json.scheduled.id)
 
         expect(logs.join('\n')).toContain(`scheduled-task:${marker}`)
@@ -211,7 +211,7 @@ describe('Nitro Server', () => {
           authorization: upstreamAuthHeader,
         },
       }))
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
 
       expect(json).toEqual({ authHeader: upstreamAuthHeader })
     })
@@ -252,7 +252,7 @@ describe('Nitro Server', () => {
     it('should deny access to protected route', async () => {
       const res = await server.fetch(new Request(new URL('/protectedRoute', server.url)))
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
 
       expect(json.message).toEqual('User does not have required role(s) to access this resource: ADMIN_ROLE')
       expect(res.status).toEqual(403)
@@ -263,7 +263,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(403)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toContain('ROLE_A')
       expect(json.message).toContain('ROLE_B')
     })
@@ -307,7 +307,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('You have access to the protected route!')
     })
 
@@ -316,7 +316,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('You have one of the required roles!')
     })
   })
@@ -378,7 +378,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.userName).toBe('testUser')
       expect(json.roles).toEqual(['ROLE_INVENTORY_READ', 'ROLE_ALARM_READ', 'ROLE_DEVICE_CONTROL'])
     })
@@ -388,7 +388,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.subscribedTenants).toEqual(expect.arrayContaining(['t12345', 't67890']))
       expect(json.deployedTenant).toBe('t12345')
       expect(json.userTenant).toBe('t12345')
@@ -399,7 +399,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.myOption).toBe('hello-world')
       expect(json['credentials.secret']).toBe('super-secret-value')
       expect(json.cacheExpiryOption).toBe('cache-initial-value')
@@ -413,7 +413,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('success')
     })
 
@@ -422,7 +422,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('success')
     })
 
@@ -433,7 +433,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('success')
     })
 
@@ -442,7 +442,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(400)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('Invalid tenant option invalidation request')
     })
 
@@ -451,7 +451,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(400)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('Provide either the all or key query parameter')
     })
 
@@ -460,7 +460,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('Your tenant is allowed!')
     })
 
@@ -469,19 +469,19 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(200)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toBe('You are from the deployed tenant!')
     })
 
     it('should keep the cached tenant option until TTL expires and then return the updated value', async () => {
       const initialRes = await server.fetch(new Request(new URL('/tenant-options', server.url)))
       expect(initialRes.status).toEqual(200)
-      const initialJson = await initialRes.json()
+      const initialJson = await initialRes.json() as Record<string, any>
       expect(initialJson.cacheExpiryOption).toBe('cache-initial-value')
 
       const updateRes = await server.fetch(new Request(new URL('/mock-tenant-option?key=cacheExpiryOption&value=cache-updated-value', server.url)))
       expect(updateRes.status).toEqual(200)
-      const updateJson = await updateRes.json()
+      const updateJson = await updateRes.json() as Record<string, any>
       expect(updateJson).toEqual({
         key: 'cacheExpiryOption',
         value: 'cache-updated-value',
@@ -493,7 +493,7 @@ describe('Nitro Server', () => {
 
       const cachedRes = await server.fetch(new Request(new URL('/tenant-options', server.url)))
       expect(cachedRes.status).toEqual(200)
-      const cachedJson = await cachedRes.json()
+      const cachedJson = await cachedRes.json() as Record<string, any>
       expect(cachedJson.cacheExpiryOption).toBe('cache-initial-value')
 
       await new Promise<void>((resolve) => {
@@ -502,9 +502,48 @@ describe('Nitro Server', () => {
 
       const refreshedRes = await server.fetch(new Request(new URL('/tenant-options', server.url)))
       expect(refreshedRes.status).toEqual(200)
-      const refreshedJson = await refreshedRes.json()
+      const refreshedJson = await refreshedRes.json() as Record<string, any>
       expect(refreshedJson.cacheExpiryOption).toBe('cache-updated-value')
     }, 8_000)
+
+    it('should fire the tenant credentials lifecycle hook when credentials are refreshed after a mocked subscription change', async () => {
+      const clearInitialRes = await server.fetch(new Request(new URL('/credentials-hook-events?clear=1', server.url)))
+      expect(clearInitialRes.status).toEqual(200)
+
+      const initialRes = await server.fetch(new Request(new URL('/subscribed-credentials', server.url)))
+      expect(initialRes.status).toEqual(200)
+      const initialJson = await initialRes.json() as Record<string, any>
+      expect(initialJson.subscribedTenants).toEqual(['t12345', 't67890'])
+
+      const clearCachedEventsRes = await server.fetch(new Request(new URL('/credentials-hook-events?clear=1', server.url)))
+      expect(clearCachedEventsRes.status).toEqual(200)
+
+      const mutateRes = await server.fetch(new Request(new URL('/subscribed-credentials?tenant=t99999&user=serviceuser3&password=pass3', server.url)))
+      expect(mutateRes.status).toEqual(200)
+      const mutateJson = await mutateRes.json() as Record<string, any>
+      expect(mutateJson.mockSubscribedTenants).toEqual(['t12345', 't67890', 't99999'])
+      expect(mutateJson.subscribedTenants).toEqual(['t12345', 't67890'])
+
+      const staleRes = await server.fetch(new Request(new URL('/subscribed-credentials', server.url)))
+      expect(staleRes.status).toEqual(200)
+      const staleJson = await staleRes.json() as Record<string, any>
+      expect(staleJson.subscribedTenants).toEqual(['t12345', 't67890'])
+
+      const refreshRes = await server.fetch(new Request(new URL('/subscribed-credentials?refresh=1', server.url)))
+      expect(refreshRes.status).toEqual(200)
+      const refreshJson = await refreshRes.json() as Record<string, any>
+      expect(refreshJson.subscribedTenants).toEqual(['t12345', 't67890', 't99999'])
+
+      const refreshEventsRes = await server.fetch(new Request(new URL('/credentials-hook-events?clear=1', server.url)))
+      expect(refreshEventsRes.status).toEqual(200)
+      const refreshEventsJson = await refreshEventsRes.json() as Record<string, any>
+      expect(refreshEventsJson.events).toEqual([
+        {
+          prevTenants: ['t12345', 't67890'],
+          nextTenants: ['t12345', 't67890', 't99999'],
+        },
+      ])
+    })
   })
 
   describe('Tenant restriction (disallowed tenant)', () => {
@@ -546,7 +585,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(403)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toContain('t00000')
       expect(json.message).toContain('not allowed')
     })
@@ -591,7 +630,7 @@ describe('Nitro Server', () => {
 
       expect(res.status).toEqual(403)
 
-      const json = await res.json()
+      const json = await res.json() as Record<string, any>
       expect(json.message).toContain('t12345')
     })
   })
@@ -634,7 +673,7 @@ describe('Nitro Server', () => {
         const res = await server.fetch(new Request(new URL('/logging/success', server.url)))
 
         expect(res.status).toEqual(200)
-        const json = await res.json()
+        const json = await res.json() as Record<string, any>
         expect(json.message).toBe('ok')
         expect(json.action).toBe('test-success')
 
@@ -665,7 +704,7 @@ describe('Nitro Server', () => {
         const res = await server.fetch(new Request(new URL('/logging/error', server.url)))
 
         expect(res.status).toEqual(400)
-        const json = await res.json()
+        const json = await res.json() as Record<string, any>
         expect(json.message).toBe('Something went wrong')
         expect(json.data.why).toBe('Test error occurred for logging verification')
         expect(json.data.fix).toBe('This is a test fixture, nothing to fix')

--- a/tests/unit/runtime.test.ts
+++ b/tests/unit/runtime.test.ts
@@ -1,5 +1,6 @@
 import { vol, fs as memFs } from 'memfs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { C8YManifest } from '../../src/types'
 import { setupRuntime } from '../../src/module/runtime'
 
 // Mock fs modules with memfs
@@ -34,7 +35,7 @@ describe('setupRuntime', () => {
     it('should generate types file with no roles or settings', () => {
       const nitro = createMockNitro()
 
-      setupRuntime(nitro, {})
+      setupRuntime(nitro, {} as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const typesPath = '/project/node_modules/.nitro/types/c8y-nitro.d.ts'
@@ -57,7 +58,7 @@ describe('setupRuntime', () => {
 
       setupRuntime(nitro, {
         roles: ['ROLE_APPLICATION_ADMIN', 'ROLE_MEASUREMENT_READ'],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const typesPath = '/project/node_modules/.nitro/types/c8y-nitro.d.ts'
@@ -77,7 +78,7 @@ describe('setupRuntime', () => {
           { key: 'feature.enabled', defaultValue: 'true' },
           { key: 'max.connections', defaultValue: '10' },
         ],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const typesPath = '/project/node_modules/.nitro/types/c8y-nitro.d.ts'
@@ -97,7 +98,7 @@ describe('setupRuntime', () => {
           { key: 'api.timeout', defaultValue: '30' },
           { key: 'cache.ttl', defaultValue: '60' },
         ],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const typesPath = '/project/node_modules/.nitro/types/c8y-nitro.d.ts'
@@ -115,7 +116,7 @@ describe('setupRuntime', () => {
     it('should respect custom generatedTypesDir', () => {
       const nitro = createMockNitro('/project', 'custom-types')
 
-      setupRuntime(nitro, {})
+      setupRuntime(nitro, {} as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const typesPath = '/project/custom-types/c8y-nitro.d.ts'
@@ -126,7 +127,7 @@ describe('setupRuntime', () => {
     it('should create directory recursively', () => {
       const nitro = createMockNitro('/project', 'nested/deep/types')
 
-      setupRuntime(nitro, {})
+      setupRuntime(nitro, {} as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const typesPath = '/project/nested/deep/types/c8y-nitro.d.ts'
@@ -140,7 +141,7 @@ describe('setupRuntime', () => {
       setupRuntime(nitro, {
         roles: ['ROLE_ADMIN'],
         settings: [{ key: 'test.key', defaultValue: 'value' }],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
 
@@ -158,7 +159,7 @@ describe('setupRuntime', () => {
     it('should generate virtual module with empty roles and keys', () => {
       const nitro = createMockNitro()
 
-      setupRuntime(nitro, {})
+      setupRuntime(nitro, {} as C8YManifest)
 
       const virtualModule = nitro.options.virtual['c8y-nitro/runtime']
 
@@ -172,7 +173,7 @@ describe('setupRuntime', () => {
 
       setupRuntime(nitro, {
         roles: ['ROLE_ADMIN', 'ROLE_USER'],
-      })
+      } as C8YManifest)
 
       const virtualModule = nitro.options.virtual['c8y-nitro/runtime']
 
@@ -189,7 +190,7 @@ describe('setupRuntime', () => {
           { key: 'key1', defaultValue: 'value1' },
           { key: 'key2', defaultValue: 'value2' },
         ],
-      })
+      } as C8YManifest)
 
       const virtualModule = nitro.options.virtual['c8y-nitro/runtime']
 
@@ -202,7 +203,7 @@ describe('setupRuntime', () => {
       setupRuntime(nitro, {
         roles: ['ROLE_TEST'],
         settings: [{ key: 'test.key', defaultValue: 'value' }],
-      })
+      } as C8YManifest)
 
       const virtualModule = nitro.options.virtual['c8y-nitro/runtime']
 
@@ -215,7 +216,7 @@ describe('setupRuntime', () => {
     it('should log debug messages', () => {
       const nitro = createMockNitro()
 
-      setupRuntime(nitro, {})
+      setupRuntime(nitro, {} as C8YManifest)
 
       expect(nitro.logger.debug).toHaveBeenCalledWith('Setting up C8Y nitro runtime')
       expect(nitro.logger.debug).toHaveBeenCalledWith(
@@ -230,7 +231,7 @@ describe('setupRuntime', () => {
 
       setupRuntime(nitro, {
         roles: ['ROLE_WITH-DASH', 'ROLE_WITH_UNDERSCORE'],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const content = generatedFiles['/project/node_modules/.nitro/types/c8y-nitro.d.ts'] as string
@@ -248,7 +249,7 @@ describe('setupRuntime', () => {
           { key: 'key-with-dashes', defaultValue: 'value' },
           { key: 'key_with_underscores', defaultValue: 'value' },
         ],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const content = generatedFiles['/project/node_modules/.nitro/types/c8y-nitro.d.ts'] as string
@@ -263,7 +264,7 @@ describe('setupRuntime', () => {
 
       setupRuntime(nitro, {
         roles: ['ROLE_SINGLE'],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const content = generatedFiles['/project/node_modules/.nitro/types/c8y-nitro.d.ts'] as string
@@ -276,7 +277,7 @@ describe('setupRuntime', () => {
 
       setupRuntime(nitro, {
         settings: [{ key: 'single.key', defaultValue: 'value' }],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const content = generatedFiles['/project/node_modules/.nitro/types/c8y-nitro.d.ts'] as string
@@ -295,7 +296,7 @@ describe('setupRuntime', () => {
 
       setupRuntime(nitro, {
         roles: ['ROLE_NEW'],
-      })
+      } as C8YManifest)
 
       const generatedFiles = vol.toJSON()
       const content = generatedFiles['/project/node_modules/.nitro/types/c8y-nitro.d.ts'] as string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
   },
-  "include": ["./src", "./types"],
+  "include": ["./src", "./tests", "./types"],
   "exclude": ["./__snapshots__/**/*"]
 }


### PR DESCRIPTION
## Summary
- add a Nitro runtime hook for subscribed tenant credential cache updates
- export a shared `TenantCredentials` type and document how to extend credential lifecycle hooks
- add fixture coverage for hook emission using one plugin and two test endpoints within an existing shared server setup

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test:run
