### PR TITLE
feat: auto-inject ROLE_OPTION_MANAGEMENT_READ when manifest settings are defined

### DIFF
--- a/src/module/manifest.ts
+++ b/src/module/manifest.ts
@@ -4,6 +4,9 @@ import { readPackage } from 'pkg-types'
 import { GENERATED_LIVENESS_ROUTE, GENERATED_READINESS_ROUTE } from './constants'
 import type { ConsolaInstance } from 'consola'
 
+const ROLE_OPTION_MANAGEMENT_READ = 'ROLE_OPTION_MANAGEMENT_READ'
+const ROLE_OPTION_MANAGEMENT_ADMIN = 'ROLE_OPTION_MANAGEMENT_ADMIN'
+
 interface PackageJsonFields {
   name: string
   version: string
@@ -107,10 +110,24 @@ export async function createC8yManifest(
 
   const key = `${name}-key`
 
+  // Auto-inject ROLE_OPTION_MANAGEMENT_READ when settings are defined, unless the
+  // user already has READ or ADMIN (admin implies read) in requiredRoles.
+  let requiredRoles = options.requiredRoles ? [...options.requiredRoles] : undefined
+  if (
+    options.settings
+    && options.settings.length > 0
+    && !requiredRoles?.includes(ROLE_OPTION_MANAGEMENT_READ)
+    && !requiredRoles?.includes(ROLE_OPTION_MANAGEMENT_ADMIN)
+  ) {
+    requiredRoles = [...(requiredRoles ?? []), ROLE_OPTION_MANAGEMENT_READ]
+    logger?.debug(`Auto-added ${ROLE_OPTION_MANAGEMENT_READ} to requiredRoles because manifest.settings are defined`)
+  }
+
   const manifest: C8YManifest = {
     ...restManifestFields,
     ...probeFields,
     ...options,
+    ...(requiredRoles !== undefined ? { requiredRoles } : {}),
     provider,
     name,
     version,

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -189,6 +189,94 @@ describe('manifest generation', () => {
         .toThrow('manifest.settings entries must define a non-empty defaultValue. Invalid keys: "credentials.secret"')
     })
 
+    describe('auto ROLE_OPTION_MANAGEMENT_READ injection', () => {
+      it('should add ROLE_OPTION_MANAGEMENT_READ when settings are defined and requiredRoles is empty', async () => {
+        mockPackageData.current = {
+          name: 'my-service',
+          version: '1.0.0',
+          author: 'Test Author',
+        }
+
+        const manifest = await createC8yManifest('/project', {
+          settings: [{ key: 'credentials.mySecret', defaultValue: 'default' }],
+        })
+
+        expect(manifest.requiredRoles).toContain('ROLE_OPTION_MANAGEMENT_READ')
+      })
+
+      it('should add ROLE_OPTION_MANAGEMENT_READ alongside existing requiredRoles', async () => {
+        mockPackageData.current = {
+          name: 'my-service',
+          version: '1.0.0',
+          author: 'Test Author',
+        }
+
+        const manifest = await createC8yManifest('/project', {
+          settings: [{ key: 'credentials.mySecret', defaultValue: 'default' }],
+          requiredRoles: ['ROLE_INVENTORY_READ'],
+        })
+
+        expect(manifest.requiredRoles).toEqual(['ROLE_INVENTORY_READ', 'ROLE_OPTION_MANAGEMENT_READ'])
+      })
+
+      it('should NOT add ROLE_OPTION_MANAGEMENT_READ when user already has it', async () => {
+        mockPackageData.current = {
+          name: 'my-service',
+          version: '1.0.0',
+          author: 'Test Author',
+        }
+
+        const manifest = await createC8yManifest('/project', {
+          settings: [{ key: 'credentials.mySecret', defaultValue: 'default' }],
+          requiredRoles: ['ROLE_OPTION_MANAGEMENT_READ'],
+        })
+
+        expect(manifest.requiredRoles?.filter((r) => r === 'ROLE_OPTION_MANAGEMENT_READ')).toHaveLength(1)
+      })
+
+      it('should NOT add ROLE_OPTION_MANAGEMENT_READ when user has ROLE_OPTION_MANAGEMENT_ADMIN', async () => {
+        mockPackageData.current = {
+          name: 'my-service',
+          version: '1.0.0',
+          author: 'Test Author',
+        }
+
+        const manifest = await createC8yManifest('/project', {
+          settings: [{ key: 'credentials.mySecret', defaultValue: 'default' }],
+          requiredRoles: ['ROLE_OPTION_MANAGEMENT_ADMIN'],
+        })
+
+        expect(manifest.requiredRoles).not.toContain('ROLE_OPTION_MANAGEMENT_READ')
+        expect(manifest.requiredRoles).toContain('ROLE_OPTION_MANAGEMENT_ADMIN')
+      })
+
+      it('should NOT add ROLE_OPTION_MANAGEMENT_READ when no settings are defined', async () => {
+        mockPackageData.current = {
+          name: 'my-service',
+          version: '1.0.0',
+          author: 'Test Author',
+        }
+
+        const manifest = await createC8yManifest('/project', {})
+
+        expect(manifest.requiredRoles).toBeUndefined()
+      })
+
+      it('should NOT add ROLE_OPTION_MANAGEMENT_READ when settings array is empty', async () => {
+        mockPackageData.current = {
+          name: 'my-service',
+          version: '1.0.0',
+          author: 'Test Author',
+        }
+
+        const manifest = await createC8yManifest('/project', {
+          settings: [],
+        })
+
+        expect(manifest.requiredRoles).toBeUndefined()
+      })
+    })
+
     it('should throw error when package.json is missing required fields', async () => {
       mockPackageData.current = {
         name: 'my-service',


### PR DESCRIPTION
## Summary

When a microservice declares `manifest.settings` entries (tenant options), the service user needs `ROLE_OPTION_MANAGEMENT_READ` to read them at runtime. Previously this had to be added manually.

This PR makes the module inject the role automatically — but only when it is actually needed and not already covered:

| Condition | Behaviour |
|---|---|
| `settings` is non-empty, no relevant role set | **auto-adds** `ROLE_OPTION_MANAGEMENT_READ` |
| User already has `ROLE_OPTION_MANAGEMENT_READ` | skipped (no duplicate) |
| User already has `ROLE_OPTION_MANAGEMENT_ADMIN` | skipped (admin implies read) |
| `settings` is absent or empty | no change |

## Changes

- `src/module/manifest.ts` — inject logic in `createC8yManifest` with a debug log when the role is added
- `tests/unit/manifest.test.ts` — 6 new tests covering all branches of the injection logic